### PR TITLE
PLATFORM-517: implemented `vault delete` and added test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ cache:
   directories:
     - vendor
 php:
-  - 5.6
   - 7.0
-
 install:
-  - composer install -o --prefer-source --no-interaction
+  - composer install --no-interaction
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+cache:
+  directories:
+    - vendor
+php:
+  - 5.6
+  - 7.0
+
+install:
+  - composer install -o --prefer-source --no-interaction
+script:
+  - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ VaultPhp - PHP API Client for HashiCorp Vault
 Example Usage
 -------------
 
-    $client = new VaultPhp\Client([
+    $client = new VaultPhp\Client(new \GuzzleHttp\Client(), [
         'endpoint' => 'http://localhost:8200',
-        'token' => '<AUTH TOKEN>',
+        'token'    => '<AUTH TOKEN>',
     ]);
 
     // Write data to Vault
@@ -24,6 +24,8 @@ Example Usage
     // Read complex data types from Vault
     echo $client->read('secret/my-complex-key')->getData('array')[2]; // 3
 
+    // Delete data from Vault
+    $client->delete('secret/my-complex-key');
 
 License
 -------

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,11 @@
     "type": "library",
     "keywords": ["hashicorp", "vault", "security", "password"],
     "require": {
-        "php": ">=5.5",
-        "guzzlehttp/guzzle": "~5|~6"
+        "php": ">=5.6",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "~4.8",
         "ext-openssl": "*",
         "ext-pcre": "*",
         "ext-json": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2ce440cfef5aecf0e35fa00a545ca0e7",
-    "content-hash": "019e2de52bf5a7718732c0f6c8ab373e",
+    "hash": "e5d54c9611f1cbcc601a30249336747f",
+    "content-hash": "442dc0e3f7a30810438382d1ce8b02de",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.0",
+            "version": "6.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "d094e337976dff9d8e2424e8485872194e768662"
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d094e337976dff9d8e2424e8485872194e768662",
-                "reference": "d094e337976dff9d8e2424e8485872194e768662",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/promises": "~1.0",
-                "guzzlehttp/psr7": "~1.1",
-                "php": ">=5.5.0"
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "~4.0",
-                "psr/log": "~1.0"
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
             },
             "type": "library",
             "extra": {
@@ -67,20 +67,20 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-03-21 20:02:09"
+            "time": "2016-10-08 15:01:37"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "bb9024c526b22f3fe6ae55a561fd70653d470aa8"
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/bb9024c526b22f3fe6ae55a561fd70653d470aa8",
-                "reference": "bb9024c526b22f3fe6ae55a561fd70653d470aa8",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2693c101803ca78b27972d84081d027fca790a1e",
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e",
                 "shasum": ""
             },
             "require": {
@@ -118,20 +118,20 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-03-08 01:15:46"
+            "time": "2016-11-18 17:47:58"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "2e89629ff057ebb49492ba08e6995d3a6a80021b"
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/2e89629ff057ebb49492ba08e6995d3a6a80021b",
-                "reference": "2e89629ff057ebb49492ba08e6995d3a6a80021b",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
                 "shasum": ""
             },
             "require": {
@@ -147,7 +147,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -176,20 +176,20 @@
                 "stream",
                 "uri"
             ],
-            "time": "2016-02-18 21:54:00"
+            "time": "2016-06-24 23:00:38"
         },
         {
             "name": "psr/http-message",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
                 "shasum": ""
             },
             "require": {
@@ -217,6 +217,7 @@
                 }
             ],
             "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
             "keywords": [
                 "http",
                 "http-message",
@@ -225,17 +226,1129 @@
                 "request",
                 "response"
             ],
-            "time": "2015-05-04 20:22:00"
+            "time": "2016-08-06 14:39:51"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27 11:43:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-09-30 07:12:33"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-11-25 06:54:22"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0|^2.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2016-11-21 14:58:47"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "^1.3.2",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-10-06 15:47:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2016-10-03 07:40:28"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2016-05-12 18:03:57"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2016-11-15 14:06:22"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "4.8.31",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "~2.1",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "~2.3",
+                "sebastian/comparator": "~1.2.2",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "~1.3",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.1|~3.0"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.8.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-12-09 02:45:31"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "2.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2015-10-02 06:51:40"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2 || ~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2016-11-19 09:18:40"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-12-08 07:14:41"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-08-18 05:49:44"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-06-17 09:04:28"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12 03:26:01"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-11-11 19:50:13"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2015-06-21 13:59:46"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7095af4b97a0955f85c8989106c249fa649011f",
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-12-10 10:07:06"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23 20:04:58"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=5.6"
     },
     "platform-dev": {
         "ext-openssl": "*",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit colors="true">
+    <php>
+        <ini name="display_errors" value="1" />
+    </php>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">tests/Unit/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace VaultPhp;
 
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Request;
 
 class Client
 {
@@ -18,57 +19,98 @@ class Client
     /** @var string */
     protected $token;
 
-    public function __construct(array $config)
+    /**
+     * @param GuzzleClient $guzzleClient
+     * @param array $config
+     */
+    public function __construct(GuzzleClient $guzzleClient, array $config)
     {
+        $this->guzzleClient = $guzzleClient;
+
         $this->setConfig($config);
     }
 
+    /**
+     * @param array $config
+     */
     public function setConfig(array $config)
     {
         $this->apiVersion = isset($config['version']) ? $config['version'] : '1';
         $this->endpoint = isset($config['endpoint']) ? $config['endpoint'] : 'https://localhost:8200';
-
         $this->token = isset($config['token']) ? $config['token'] : null;
-
-        $this->guzzleClient = new GuzzleClient([
-           'base_uri' => $this->endpoint,
-           'timeout' => isset($config['timeout']) ? $config['timeout'] : 30.0,
-           'headers' => [
-                'X-Vault-Token' => $this->token
-           ]
-        ]);
     }
 
+    /**
+     * @return string
+     */
     public function getEndpoint()
     {
         return $this->endpoint;
     }
 
+    /**
+     * @return GuzzleClient
+     */
     public function getGuzzleClient()
     {
         return $this->guzzleClient;
     }
 
+    /**
+     * @return string
+     */
     public function getApiVersion()
     {
         return $this->apiVersion;
     }
 
+    /**
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    /**
+     * @param $token
+     */
     public function setToken($token)
     {
         $this->token = $token;
     }
 
+    /**
+     * @param $uriPath
+     * @return string
+     */
     protected function makeUri($uriPath)
     {
-        return '/v'.$this->apiVersion.'/'.ltrim($uriPath, '/');
+        return $this->endpoint . '/v' . $this->apiVersion . '/' . ltrim($uriPath, '/');
     }
 
+    /**
+     * @param $method
+     * @param $uriPath
+     * @param array|null $params
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function request($method, $uriPath, array $params = null)
     {
-        return $this->guzzleClient->request($method, $this->makeUri($uriPath), $params);
+        $request = new Request(
+            $method,
+            $this->makeUri($uriPath),
+            ['X-Vault-Token' => $this->token]
+        );
+
+        return $this->guzzleClient->send($request, $params);
     }
 
+    /**
+     * @param $method
+     * @param $parameters
+     * @return mixed
+     */
     public function __call($method, $parameters)
     {
         $class = 'VaultPhp\\Commands\\'.ucwords($method).'Command';

--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -24,12 +24,19 @@ abstract class AbstractCommand
     /** @var any */
     protected $body;
 
+    /**
+     * @param Client $client
+     * @param array $parameters
+     */
     public function __construct(Client $client, array $parameters)
     {
         $this->client = $client;
         $this->setRequestParameters($parameters);
     }
 
+    /**
+     * @return Client
+     */
     public function getClient()
     {
         return $this->client;
@@ -38,16 +45,13 @@ abstract class AbstractCommand
     protected abstract function setRequestParameters(array $parameters);
 
     /**
-        Run Command
-
-        @return AbstractResponse
-    */
+     * @return mixed
+     */
     public function run()
     {
         $params = [];
 
-        if($this->body)
-        {
+        if ($this->body) {
             $params['json'] = $this->body;
         }
 
@@ -56,6 +60,10 @@ abstract class AbstractCommand
         return $this->makeResponse($data);
     }
 
+    /**
+     * @param Response $response
+     * @return mixed
+     */
     protected function makeResponse(Response $response)
     {
         return new $this->responseClass($this, $response);

--- a/src/Commands/DeleteCommand.php
+++ b/src/Commands/DeleteCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace VaultPhp\Commands;
+
+use VaultPhp\Responses\DeleteResponse;
+
+class DeleteCommand extends AbstractCommand
+{
+    /** @var string */
+    protected $method = 'DELETE';
+
+    protected $responseClass = DeleteResponse::class;
+
+    /**
+     * @param array $parameters
+     */
+    protected function setRequestParameters(array $parameters)
+    {
+        list($path) = $parameters;
+
+        $this->uriPath = '/'.ltrim($path, '/');
+    }
+}

--- a/src/Commands/ReadCommand.php
+++ b/src/Commands/ReadCommand.php
@@ -8,6 +8,9 @@ class ReadCommand extends AbstractCommand
 {
     protected $responseClass = ReadResponse::class;
 
+    /**
+     * @param array $parameters
+     */
     protected function setRequestParameters(array $parameters)
     {
         list($path) = $parameters;

--- a/src/Commands/WriteCommand.php
+++ b/src/Commands/WriteCommand.php
@@ -11,15 +11,16 @@ class WriteCommand extends AbstractCommand
 
     protected $responseClass = WriteResponse::class;
 
+    /**
+     * @param array $parameters
+     */
     protected function setRequestParameters(array $parameters)
     {
         list($path, $data) = $parameters;
 
-
         $this->uriPath = '/'.ltrim($path, '/');
 
-        if($data)
-        {
+        if ($data) {
             $this->body = $data;
         }
     }

--- a/src/Responses/AbstractResponse.php
+++ b/src/Responses/AbstractResponse.php
@@ -18,6 +18,10 @@ abstract class AbstractResponse
     /** @var array */
     protected $jsonBody;
 
+    /**
+     * @param AbstractCommand $command
+     * @param Response $response
+     */
     public function __construct(AbstractCommand $command, Response $response)
     {
         $this->command = $command;
@@ -26,16 +30,25 @@ abstract class AbstractResponse
         $this->processResponse();
     }
 
+    /**
+     * @return int
+     */
     public function getStatus()
     {
         return $this->response->getStatusCode();
     }
 
+    /**
+     * @return AbstractCommand
+     */
     public function getCommand()
     {
         return $this->command;
     }
 
+    /**
+     * @return mixed
+     */
     public function getWarnings()
     {
         return $this->jsonBody['warnings'];
@@ -43,8 +56,7 @@ abstract class AbstractResponse
 
     private function parseResponse()
     {
-        if($body = $this->response->getBody())
-        {
+        if ($body = $this->response->getBody()) {
             $this->jsonBody = json_decode($body, true);
         }
     }

--- a/src/Responses/DeleteResponse.php
+++ b/src/Responses/DeleteResponse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace VaultPhp\Responses;
+
+use GuzzleHttp\Psr7\Response;
+
+use VaultPhp\Client;
+
+class DeleteResponse extends AbstractResponse
+{
+}

--- a/src/Responses/ReadResponse.php
+++ b/src/Responses/ReadResponse.php
@@ -8,27 +8,40 @@ use VaultPhp\Client;
 
 class ReadResponse extends AbstractResponse
 {
+    /**
+     * @return mixed
+     */
     public function getLeaseId()
     {
         return $this->jsonBody['lease_id'];
     }
 
+    /**
+     * @return mixed
+     */
     public function getLeaseDuration()
     {
         return $this->jsonBody['leaseDuration'];
     }
 
+    /**
+     * @return mixed
+     */
     public function getRenewable()
     {
         return $this->jsonBody['renewable'];
     }
 
+    /**
+     * @param null $key
+     * @param null $default
+     * @return null
+     */
     public function getData($key = null, $default = null)
     {
         $data = $this->jsonBody['data'];
 
-        if(!$key)
-        {
+        if (!$key) {
             return $data;
         }
 

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace VaultPhp\Test\Unit;
+
+use GuzzleHttp\Psr7\Request;
+use VaultPhp\Client;
+use GuzzleHttp\Client as GuzzleClient;
+
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetConfig()
+    {
+        $expectedApiVersion = 0;
+        $expectedEndpoint   = 'https://localhost';
+        $expectedToken      = 'asdf';
+
+        $client = new Client(new GuzzleClient, []);
+        $client->setConfig([
+            'version'  => $expectedApiVersion,
+            'endpoint' => $expectedEndpoint,
+            'token'    => $expectedToken,
+        ]);
+
+        $this->assertEquals($expectedApiVersion, $client->getApiVersion());
+        $this->assertEquals($expectedEndpoint, $client->getEndpoint());
+        $this->assertEquals($expectedToken, $client->getToken());
+    }
+
+    public function testConstructorSetsConfig()
+    {
+        $expectedApiVersion = 0;
+        $expectedEndpoint   = 'https://localhost';
+        $expectedToken      = 'asdf';
+
+        $client = new Client(new GuzzleClient, [
+            'version'  => $expectedApiVersion,
+            'endpoint' => $expectedEndpoint,
+            'token'    => $expectedToken,
+        ]);
+
+        $this->assertEquals($expectedApiVersion, $client->getApiVersion());
+        $this->assertEquals($expectedEndpoint, $client->getEndpoint());
+        $this->assertEquals($expectedToken, $client->getToken());
+    }
+
+    public function testRequestSendsCorrectRequest()
+    {
+        $expectedApiVersion = 0;
+        $expectedEndpoint   = 'https://localhost';
+        $expectedToken      = 'asds89j1239e';
+        $expectedUriPath    = 'secret/test';
+        $expectedMethod     = 'POST';
+        $expectedParams     = [''];
+
+        $expectedRequest = new Request(
+            $expectedMethod,
+            $expectedEndpoint . '/v' . $expectedApiVersion . '/' . ltrim($expectedUriPath, '/'),
+            ['X-Vault-Token' => $expectedToken]
+        );
+
+        $guzzleClient = $this->getMock(GuzzleClient::class, ['send']);
+        $guzzleClient
+            ->expects($this->once())
+            ->method('send')
+            ->with($expectedRequest, $expectedParams);
+
+        $client = new Client($guzzleClient, [
+            'version'  => $expectedApiVersion,
+            'endpoint' => $expectedEndpoint,
+            'token'    => $expectedToken,
+        ]);
+        $client->request($expectedMethod, $expectedUriPath, $expectedParams);
+    }
+}

--- a/tests/Unit/Commands/DeleteCommandTest.php
+++ b/tests/Unit/Commands/DeleteCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace VaultPhp\Test\Unit;
+
+use GuzzleHttp\Psr7\Request;
+use VaultPhp\Client;
+use VaultPhp\Commands\DeleteCommand;
+use VaultPhp\Responses\DeleteResponse;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+
+class DeleteCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRunSendsCorrectRequestAndReturnsCorrectResponse()
+    {
+        $expectedApiVersion = 0;
+        $expectedEndpoint   = 'https://localhost';
+        $expectedToken      = 'asds89j1239e';
+        $expectedUriPath    = 'secret/test';
+        $expectedMethod     = 'DELETE';
+        $expectedParams     = [];
+
+        $expectedGuzzleRequest = new Request(
+            $expectedMethod,
+            $expectedEndpoint . '/v' . $expectedApiVersion . '/' . ltrim($expectedUriPath, '/'),
+            ['X-Vault-Token' => $expectedToken]
+        );
+        $expectedGuzzleResponse = new GuzzleResponse();
+
+        $guzzleClient = $this->getMock(GuzzleClient::class, ['send']);
+        $guzzleClient
+            ->expects($this->once())
+            ->method('send')
+            ->with($expectedGuzzleRequest, $expectedParams)
+            ->will($this->returnValue($expectedGuzzleResponse));
+
+        $client = new Client($guzzleClient, [
+            'version'  => $expectedApiVersion,
+            'endpoint' => $expectedEndpoint,
+            'token'    => $expectedToken,
+        ]);
+
+        $deleteCommand     = new DeleteCommand($client, [$expectedUriPath]);
+        $expectedResponse = new DeleteResponse($deleteCommand, $expectedGuzzleResponse);
+
+        $this->assertEquals($expectedResponse, $deleteCommand->run());
+    }
+}

--- a/tests/Unit/Commands/ReadCommandTest.php
+++ b/tests/Unit/Commands/ReadCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace VaultPhp\Test\Unit;
+
+use GuzzleHttp\Psr7\Request;
+use VaultPhp\Client;
+use VaultPhp\Commands\ReadCommand;
+use VaultPhp\Responses\ReadResponse;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+
+class ReadCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRunSendsCorrectRequestAndReturnsCorrectResponse()
+    {
+        $expectedApiVersion = 0;
+        $expectedEndpoint   = 'https://localhost';
+        $expectedToken      = 'asds89j1239e';
+        $expectedUriPath    = 'secret/test';
+        $expectedMethod     = 'GET';
+        $expectedParams     = [];
+
+        $expectedGuzzleRequest = new Request(
+            $expectedMethod,
+            $expectedEndpoint . '/v' . $expectedApiVersion . '/' . ltrim($expectedUriPath, '/'),
+            ['X-Vault-Token' => $expectedToken]
+        );
+        $expectedGuzzleResponse = new GuzzleResponse();
+
+        $guzzleClient = $this->getMock(GuzzleClient::class, ['send']);
+        $guzzleClient
+            ->expects($this->once())
+            ->method('send')
+            ->with($expectedGuzzleRequest, $expectedParams)
+            ->will($this->returnValue($expectedGuzzleResponse));
+
+        $client = new Client($guzzleClient, [
+            'version'  => $expectedApiVersion,
+            'endpoint' => $expectedEndpoint,
+            'token'    => $expectedToken,
+        ]);
+
+        $readCommand     = new ReadCommand($client, [$expectedUriPath]);
+        $expectedResponse = new ReadResponse($readCommand, $expectedGuzzleResponse);
+
+        $this->assertEquals($expectedResponse, $readCommand->run());
+    }
+}

--- a/tests/Unit/Commands/WriteCommandTest.php
+++ b/tests/Unit/Commands/WriteCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace VaultPhp\Test\Unit;
+
+use GuzzleHttp\Psr7\Request;
+use VaultPhp\Client;
+use VaultPhp\Commands\WriteCommand;
+use VaultPhp\Responses\WriteResponse;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+
+class WriteCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRunSendsCorrectRequestAndReturnsCorrectResponse()
+    {
+        $expectedApiVersion = 0;
+        $expectedEndpoint   = 'https://localhost';
+        $expectedToken      = 'asds89j1239e';
+        $expectedUriPath    = 'secret/test';
+        $expectedPayload    = ['cert' => '234r43fgrsgdfg'];
+        $expectedMethod     = 'POST';
+        $expectedParams     = ['json' => $expectedPayload];
+
+        $expectedGuzzleRequest = new Request(
+            $expectedMethod,
+            $expectedEndpoint . '/v' . $expectedApiVersion . '/' . ltrim($expectedUriPath, '/'),
+            ['X-Vault-Token' => $expectedToken]
+        );
+        $expectedGuzzleResponse = new GuzzleResponse();
+
+        $guzzleClient = $this->getMock(GuzzleClient::class, ['send']);
+        $guzzleClient
+            ->expects($this->once())
+            ->method('send')
+            ->with($expectedGuzzleRequest, $expectedParams)
+            ->will($this->returnValue($expectedGuzzleResponse));
+
+        $client = new Client($guzzleClient, [
+            'version'  => $expectedApiVersion,
+            'endpoint' => $expectedEndpoint,
+            'token'    => $expectedToken,
+        ]);
+
+        $writeCommand     = new WriteCommand($client, [$expectedUriPath, $expectedPayload]);
+        $expectedResponse = new WriteResponse($writeCommand, $expectedGuzzleResponse);
+
+        $this->assertEquals($expectedResponse, $writeCommand->run());
+    }
+}

--- a/tests/Unit/Responses/ReadResponseTest.php
+++ b/tests/Unit/Responses/ReadResponseTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace VaultPhp\Test\Unit;
+
+use VaultPhp\Client;
+use VaultPhp\Commands\ReadCommand;
+use VaultPhp\Responses\ReadResponse;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+
+class ReadResponseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetStatus()
+    {
+        $readResponse = new ReadResponse(
+            new ReadCommand(new Client(new GuzzleClient(), []), ['secret/test']),
+            new GuzzleResponse(204)
+        );
+        $this->assertEquals(204, $readResponse->getStatus());
+    }
+
+    public function testGetCommand()
+    {
+        $expectedCommand = new ReadCommand(new Client(new GuzzleClient(), []), ['secret/test']);
+        $readResponse    = new ReadResponse($expectedCommand, new GuzzleResponse());
+
+        $this->assertEquals($expectedCommand, $readResponse->getCommand());
+    }
+
+    public function testGetWarnings()
+    {
+        $expectedPayload = ['warnings' => 'asdf'];
+        $readResponse    = new ReadResponse(
+            new ReadCommand(new Client(new GuzzleClient(), []), ['secret/test']),
+            new GuzzleResponse(204, [], json_encode($expectedPayload, true))
+        );
+
+        $this->assertEquals($expectedPayload['warnings'], $readResponse->getWarnings());
+    }
+
+    public function testGetLeaseId()
+    {
+        $expectedPayload = ['lease_id' => 123];
+        $readResponse    = new ReadResponse(
+            new ReadCommand(new Client(new GuzzleClient(), []), ['secret/test']),
+            new GuzzleResponse(204, [], json_encode($expectedPayload, true))
+        );
+
+        $this->assertEquals($expectedPayload['lease_id'], $readResponse->getLeaseId());
+    }
+
+    public function testGetLeaseDuration()
+    {
+        $expectedPayload = ['leaseDuration' => 3600];
+        $readResponse    = new ReadResponse(
+            new ReadCommand(new Client(new GuzzleClient(), []), ['secret/test']),
+            new GuzzleResponse(204, [], json_encode($expectedPayload, true))
+        );
+
+        $this->assertEquals($expectedPayload['leaseDuration'], $readResponse->getLeaseDuration());
+    }
+
+    public function testGetRenewable()
+    {
+        $expectedPayload = ['renewable' => true];
+        $readResponse    = new ReadResponse(
+            new ReadCommand(new Client(new GuzzleClient(), []), ['secret/test']),
+            new GuzzleResponse(204, [], json_encode($expectedPayload, true))
+        );
+
+        $this->assertEquals($expectedPayload['renewable'], $readResponse->getRenewable());
+    }
+
+    public function testGetData()
+    {
+        $expectedPayload = ['data' => [
+            'cert'   => 'dsafff24f443fd',
+            'expiry' => 1482210900,
+        ]];
+        $readResponse    = new ReadResponse(
+            new ReadCommand(new Client(new GuzzleClient(), []), ['secret/test']),
+            new GuzzleResponse(204, [], json_encode($expectedPayload, true))
+        );
+
+        $this->assertEquals($expectedPayload['data'], $readResponse->getData());
+    }
+
+    public function testGetDataReturnsCorrectValueForKey()
+    {
+        $expectedPayload = ['data' => [
+            'cert'   => 'dsafff24f443fd',
+            'expiry' => 1482210900,
+        ]];
+        $readResponse    = new ReadResponse(
+            new ReadCommand(new Client(new GuzzleClient(), []), ['secret/test']),
+            new GuzzleResponse(204, [], json_encode($expectedPayload, true))
+        );
+
+        $this->assertEquals($expectedPayload['data']['cert'], $readResponse->getData('cert'));
+    }
+
+    public function testGetDataReturnsCorrectDefaultValueWhenKeyDoesntExist()
+    {
+        $expectedPayload = ['data' => [
+            'cert'   => 'dsafff24f443fd',
+            'expiry' => 1482210900,
+        ]];
+        $readResponse    = new ReadResponse(
+            new ReadCommand(new Client(new GuzzleClient(), []), ['secret/test']),
+            new GuzzleResponse(204, [], json_encode($expectedPayload, true))
+        );
+
+        $defaultValueForProvider = 'N/A';
+        $this->assertEquals($defaultValueForProvider, $readResponse->getData('provider', $defaultValueForProvider));
+    }
+}


### PR DESCRIPTION
This PR adds required `vault delete` command and adds test coverage. To facilitate testing the signature of the client was modified slightly so that guzzle can be injected instead magically instantiated in the constructor.

ping @rayward @bigcommerce-labs/platform 